### PR TITLE
Remove React as a peerDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,6 @@
     "test:watch": "nwb test-react --server"
   },
   "dependencies": {},
-  "peerDependencies": {
-    "react": "15.x"
-  },
   "devDependencies": {
     "nwb": "0.15.x",
     "preact": "^7.2.0",
@@ -31,7 +28,10 @@
   "author": "",
   "homepage": "",
   "license": "MIT",
-  "repository": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tkh44/shallow-compare"
+  },
   "keywords": [
     "react-component"
   ]


### PR DESCRIPTION
Closes #1 

Ran into this while upgrading a project to React 16.

I also added a `repository` field, it was a bit tricky finding the project from the npm package.